### PR TITLE
non hiredis version of soulheart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,5 @@ gem 'vegas',      '>= 0.1.0'
 gem 'sinatra'
 
 platforms :ruby do
-  gem 'hiredis'
   gem 'redis', '>= 3.2.0', require: ['redis', 'redis/connection/hiredis']
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,6 @@ DEPENDENCIES
   bundler
   guard
   guard-rspec (~> 4.2.8)
-  hiredis
   rack-test
   rake
   redis (>= 3.2.0)

--- a/lib/soulheart/config.rb
+++ b/lib/soulheart/config.rb
@@ -30,7 +30,6 @@ module Soulheart
       @redis ||= (
         url = URI(@redis_url || ENV['REDIS_URL'] || 'redis://127.0.0.1:6379/0')
         ::Redis.new(
-          driver: (jruby? ? :ruby : :hiredis),
           host: url.host,
           port: url.port,
           db: url.path[1..-1],


### PR DESCRIPTION
Bike Index is using a TLS version of Redis, which hiredis doesn't support.

I'm unclear how to support both, so just pulling hiredis and bundling this branch for now